### PR TITLE
Fix double bars in navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,13 +1,9 @@
 <nav class="site-nav">
   <strong>
-    <a href="{{ '/' relative_url }}">Početna</a>
-    |
-    <a href="{{ '/main_pages/prva.html' relative_url }}">Prva godina</a>
-    |
-    <a href="{{ '/main_pages/druga.html' relative_url }}">Druga godina</a>
-    |
-    <a href="{{ '/main_pages/treca.html' relative_url }}">Treća godina</a>
-    |
-    <a href="{{ '/main_pages/cetvrta.html' relative_url }}">Četvrta godina</a>
+    <a href="{{ '/' | relative_url }}">Početna</a>
+    <a href="{{ '/main_pages/prva.html' | relative_url }}">Prva godina</a>
+    <a href="{{ '/main_pages/druga.html' | relative_url }}">Druga godina</a>
+    <a href="{{ '/main_pages/treca.html' | relative_url }}">Treća godina</a>
+    <a href="{{ '/main_pages/cetvrta.html' | relative_url }}">Četvrta godina</a>
   </strong>
 </nav>


### PR DESCRIPTION
Remove redundant hardcoded pipe separators from `_includes/nav.html` and fix `relative_url` filter syntax to resolve double separators in the navigation bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7661c7f-d587-480c-aa46-7d0981df27e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7661c7f-d587-480c-aa46-7d0981df27e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

